### PR TITLE
Fix frontend logo asset path

### DIFF
--- a/frontend/src/componentes/navbar.jsx
+++ b/frontend/src/componentes/navbar.jsx
@@ -5,6 +5,7 @@ import { exibirAlertaConfirmacao } from "../hooks/useAlert";
 import { useState } from "react";
 import AccessibilityMenu from "./acessibilidade";
 import { useAccessibility } from "../contexts/AccessibilityContext";
+import agrosmartLogo from "../../Vector.svg";
 import folhaLogo from "../assets/folha.svg";
 
 export default function Navbar() {
@@ -35,7 +36,7 @@ export default function Navbar() {
       <div className="flex justify-between items-center px-8 py-4 max-w-7xl mx-auto">
         {/* Logo - Dynamically swaps between Vector and Folha based on Dark Mode */}
         <Link to="/" className="flex items-center gap-2">
-          <img src={darkMode ? folhaLogo : "/Vector.svg"} alt="AgroSmart" className="w-8 h-8 relative z-10" />
+          <img src={darkMode ? folhaLogo : agrosmartLogo} alt="AgroSmart" className="w-8 h-8 relative z-10" />
           <span className="text-xl font-extrabold tracking-tighter text-emerald-950 dark-theme-text-inverter">AgroSmart</span>
         </Link>
 

--- a/frontend/src/pages/login/Login.jsx
+++ b/frontend/src/pages/login/Login.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import ReCAPTCHA from "react-google-recaptcha";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
+import agrosmartLogo from "../../../Vector.svg";
 import loginImg from "../../assets/cadastro.jpg";
 import eyeOff from "../../assets/eye-off.svg";
 import eye from "../../assets/eye.svg";
@@ -83,7 +84,7 @@ export default function Login() {
           <div className="flex-1">
             <div className="text-center mb-8">
               <div className="w-12 h-12 bg-[#1B4332] rounded-2xl flex items-center justify-center mx-auto mb-4">
-                <img src="/Vector.svg" alt="AgroSmart" className="w-6 h-6 brightness-0 invert" />
+                <img src={agrosmartLogo} alt="AgroSmart" className="w-6 h-6 brightness-0 invert" />
               </div>
               <h2 className="text-2xl font-extrabold text-[#012d1d] mb-1">
                 Bem-vindo de volta!


### PR DESCRIPTION
Corrige o caminho da logo no navbar e no login para usar import do Vite em vez de /Vector.svg absoluto.