### PR TITLE
fix: protect cotacoes route and allow vercel origins

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -38,13 +38,30 @@ const configuredCorsOrigins = [
 const allowedOrigins = [
   "http://localhost:5173",
   "http://localhost:3000",
-  ...configuredCorsOrigins,
+  ...configuredCorsOrigins.filter((origin) => !origin.includes("*")),
 ].map((origin) => origin.replace(/\/$/, ""));
+
+const wildcardOrigins = configuredCorsOrigins
+  .filter((origin) => origin.includes("*"))
+  .map((origin) => {
+    const normalized = origin.replace(/\/$/, "");
+    const escaped = normalized.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`^${escaped.replace(/\*/g, ".*")}$`);
+  });
+
+function isOriginAllowed(origin) {
+  if (!origin) return true;
+  const normalized = origin.replace(/\/$/, "");
+  return (
+    allowedOrigins.includes(normalized) ||
+    wildcardOrigins.some((pattern) => pattern.test(normalized))
+  );
+}
 
 app.use(
   cors({
     origin(origin, callback) {
-      if (!origin || allowedOrigins.includes(origin.replace(/\/$/, ""))) {
+      if (isOriginAllowed(origin)) {
         return callback(null, true);
       }
 
@@ -143,10 +160,11 @@ app.use("/api/responde-agro", respondeAgroRoutes);
 import createConfiguracaoRoutes from "./routes/configuracao.js";
 app.use("/api/configuracao", verifyToken, createConfiguracaoRoutes(pool));
 
+import createCotacoesRoutes from "./routes/cotacoes.js";
+app.use("/api/cotacoes", verifyToken, createCotacoesRoutes(pool));
+
 import usuarios from "./routes/usuarios.js";
 app.use("/api", verifyToken, usuarios);
-import createCotacoesRoutes from "./routes/cotacoes.js";
-app.use("/api/cotacoes", createCotacoesRoutes(pool));
 
 const swaggerDocument = {
   openapi: "3.0.0",

--- a/render.yaml
+++ b/render.yaml
@@ -19,6 +19,8 @@ services:
         sync: false
       - key: FRONTEND_URL
         sync: false
+      - key: CORS_ORIGIN
+        sync: false
       - key: JWT_SECRET
         generateValue: true
       - key: CAPTCHA_ENABLED


### PR DESCRIPTION
## Resumo`n- Mantem /api/cotacoes protegida por token, mas registra a rota antes do middleware generico de /api.`n- Permite configurar origens CORS com wildcard para previews da Vercel, como https://*.vercel.app.`n- Explicita CORS_ORIGIN no render.yaml.`n`n## Validacao`n- Commit local criado: 7fa302d.`n- Node nao esta disponivel no terminal local para rodar node --check.