### PR TITLE
fix: select cotacoes coop with available data

### DIFF
--- a/frontend/src/pages/dashboard/Dashboard.jsx
+++ b/frontend/src/pages/dashboard/Dashboard.jsx
@@ -301,7 +301,8 @@ const DashboardPage = () => {
   useEffect(() => {
     const isSelectedInList = displayedData.some(c => c.nome === selectedCoopName);
     if (!isSelectedInList) {
-        setSelectedCoopName(displayedData.length > 0 ? displayedData[0].nome : null);
+        const firstWithProducts = displayedData.find(c => c.produtos?.length > 0);
+        setSelectedCoopName(firstWithProducts?.nome || displayedData[0]?.nome || null);
     }
   }, [displayedData, selectedCoopName]);
 


### PR DESCRIPTION
## Resumo`n- Quando a API retorna algumas cooperativas vazias, o dashboard agora seleciona automaticamente a primeira cooperativa com produtos.`n- Evita tela aparentemente vazia quando COAMO/LAR/GRANOS estao sem dados e CVALE possui cotacoes.`n`n## Validacao`n- API de cotacoes protegida validada em producao com JWT: 200 OK.`n- Resposta atual possui dados em cvale e arrays vazios nas demais cooperativas.