### PR TITLE
fix: skip empty cotacoes cooperativas by default

### DIFF
--- a/frontend/src/pages/dashboard/Dashboard.jsx
+++ b/frontend/src/pages/dashboard/Dashboard.jsx
@@ -299,10 +299,13 @@ const DashboardPage = () => {
   }, [apiCooperativas, filteredData, filtroCooperativa, searchTerm]);
 
   useEffect(() => {
-    const isSelectedInList = displayedData.some(c => c.nome === selectedCoopName);
-    if (!isSelectedInList) {
-        const firstWithProducts = displayedData.find(c => c.produtos?.length > 0);
-        setSelectedCoopName(firstWithProducts?.nome || displayedData[0]?.nome || null);
+    const selectedCoop = displayedData.find(c => c.nome === selectedCoopName);
+    const firstWithProducts = displayedData.find(c => c.produtos?.length > 0);
+    const shouldPreferCoopWithProducts =
+      firstWithProducts && (!selectedCoop || selectedCoop.produtos?.length === 0);
+
+    if (shouldPreferCoopWithProducts || (!selectedCoop && displayedData.length > 0)) {
+      setSelectedCoopName(firstWithProducts?.nome || displayedData[0]?.nome || null);
     }
   }, [displayedData, selectedCoopName]);
 


### PR DESCRIPTION
## Resumo`n- Corrige o dashboard para trocar automaticamente de cooperativa quando a selecionada existe, mas nao possui produtos.`n- Resolve o caso de producao onde COAMO esta vazia e CVALE tem cotacoes, evitando tela em branco.`n`n## Validacao`n- Confirmado pelo console de producao que a API retorna cvale com 3 itens e coamo/larAgro/granos vazios.