### PR TITLE
feat: improve cotacoes dashboard with simple analytics

### DIFF
--- a/backend/routes/cotacoes.js
+++ b/backend/routes/cotacoes.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import axios from 'axios';
+import { gerarAnaliseCotacoes } from '../services/cotacoesAnalise.js';
 
 const SCRAPING_API_URL = (
   process.env.AGROSMART_SCRAPING_API_URL || 'https://agrosmartapi.onrender.com'
@@ -29,7 +30,7 @@ export default function createCotacoesRoutes(pool) {
   });
 
   router.get('/', (_req, res) => {
-    res.json({ ok: true, routes: ['/todos', '/historico', '/refresh', '/cache-status'] });
+    res.json({ ok: true, routes: ['/todos', '/historico', '/analise', '/refresh', '/cache-status'] });
   });
 
   router.get('/todos', async (_req, res) => {
@@ -103,6 +104,20 @@ export default function createCotacoesRoutes(pool) {
     } catch (err) {
       console.error('Erro na rota /api/cotacoes/cache-status:', err.message || err);
       res.status(500).json({ error: 'Erro ao consultar cache de cotacoes' });
+    }
+  });
+
+  router.get('/analise', async (req, res) => {
+    try {
+      const analise = await gerarAnaliseCotacoes(pool, {
+        grao: req.query.grao,
+        period: req.query.period,
+      });
+
+      res.json(analise);
+    } catch (err) {
+      console.error('Erro na rota /api/cotacoes/analise:', err.message || err);
+      res.status(500).json({ error: 'Erro ao gerar analise de cotacoes' });
     }
   });
 

--- a/backend/services/cotacoesAnalise.js
+++ b/backend/services/cotacoesAnalise.js
@@ -1,0 +1,314 @@
+const PROVEDOR_LABELS = {
+  coamo: 'COAMO',
+  larAgro: 'LAR',
+  granos: 'GRANOS',
+  cvale: 'CVALE',
+};
+
+const PERIOD_DAYS = {
+  '7d': 7,
+  '30d': 30,
+  '6m': 180,
+  '1y': 365,
+};
+
+export async function gerarAnaliseCotacoes(pool, filtros = {}) {
+  const graoFiltro = normalizarGrao(filtros.grao || '');
+  const period = PERIOD_DAYS[filtros.period] ? filtros.period : '30d';
+  const since = new Date();
+  since.setDate(since.getDate() - PERIOD_DAYS[period]);
+
+  const [cacheResult, historicoResult] = await Promise.all([
+    pool.query(
+      'SELECT provedor, dados, data_atualizacao FROM tb_cotacoes_cache ORDER BY provedor'
+    ),
+    buscarHistorico(pool, since, graoFiltro),
+  ]);
+
+  const cotacoesAtuais = extrairCotacoesAtuais(cacheResult.rows).filter((item) =>
+    graoFiltro ? item.grao === graoFiltro : true
+  );
+  const historico = historicoResult.rows
+    .map((row) => ({
+      provedor: row.provedor,
+      grao: normalizarGrao(row.grao),
+      preco: Number(row.preco),
+      data: row.dt,
+    }))
+    .filter((item) => item.grao && Number.isFinite(item.preco));
+
+  const graos = Array.from(
+    new Set([...cotacoesAtuais.map((item) => item.grao), ...historico.map((item) => item.grao)])
+  ).sort();
+
+  const analisesPorGrao = graos.map((grao) =>
+    analisarGrao(
+      grao,
+      cotacoesAtuais.filter((item) => item.grao === grao),
+      historico.filter((item) => item.grao === grao)
+    )
+  );
+
+  const estatisticas = calcularEstatisticas(cotacoesAtuais);
+  const melhoresPrecos = analisesPorGrao
+    .map((item) => item.melhorPreco)
+    .filter(Boolean)
+    .sort((a, b) => b.preco - a.preco);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    filters: {
+      grao: graoFiltro || null,
+      period,
+    },
+    resumo: gerarResumo(analisesPorGrao, estatisticas),
+    estatisticas,
+    melhoresPrecos,
+    graos: analisesPorGrao,
+  };
+}
+
+async function buscarHistorico(pool, since, graoFiltro) {
+  const params = [since];
+  let whereGrao = '';
+
+  if (graoFiltro) {
+    params.push(`%${graoFiltro}%`);
+    whereGrao = 'AND grao ILIKE $2';
+  }
+
+  return pool.query(
+    `
+      SELECT provedor, grao, preco, COALESCE(data_hora, created_at) AS dt
+      FROM tb_cotacoes_historico
+      WHERE COALESCE(data_hora, created_at) >= $1
+        AND preco IS NOT NULL
+        ${whereGrao}
+      ORDER BY dt ASC
+    `,
+    params
+  );
+}
+
+function extrairCotacoesAtuais(rows) {
+  const items = [];
+
+  for (const row of rows) {
+    const dados = Array.isArray(row.dados) ? row.dados : [];
+    for (const item of dados) {
+      const grao = normalizarGrao(item?.grao);
+      const preco = parsePreco(item?.preco);
+
+      if (!grao || !Number.isFinite(preco)) continue;
+
+      items.push({
+        provedor: PROVEDOR_LABELS[row.provedor] || row.provedor,
+        grao,
+        preco,
+        precoFormatado: formatCurrency(preco),
+        local: item.local || null,
+        unidade: item.unidade || null,
+        data_hora: item.data_hora || row.data_atualizacao,
+        dataAtualizacaoCache: row.data_atualizacao,
+      });
+    }
+  }
+
+  return items;
+}
+
+function analisarGrao(grao, atuais, historico) {
+  const atualOrdenado = [...atuais].sort((a, b) => b.preco - a.preco);
+  const melhorPreco = atualOrdenado[0]
+    ? {
+        grao,
+        cooperativa: atualOrdenado[0].provedor,
+        preco: atualOrdenado[0].preco,
+        precoFormatado: atualOrdenado[0].precoFormatado,
+        local: atualOrdenado[0].local,
+      }
+    : null;
+  const precoAtual = media(atuais.map((item) => item.preco));
+  const serie = consolidarSerie(historico);
+  const precoAnterior = serie.length >= 2 ? serie[serie.length - 2].price : null;
+  const variacaoPercentual =
+    Number.isFinite(precoAtual) && Number.isFinite(precoAnterior) && precoAnterior > 0
+      ? ((precoAtual - precoAnterior) / precoAnterior) * 100
+      : null;
+  const tendencia = classificarTendencia(variacaoPercentual);
+
+  return {
+    grao,
+    tendencia,
+    variacaoPercentual:
+      variacaoPercentual === null ? null : Number(variacaoPercentual.toFixed(2)),
+    precoAtual: Number.isFinite(precoAtual) ? Number(precoAtual.toFixed(2)) : null,
+    precoAtualFormatado: Number.isFinite(precoAtual) ? formatCurrency(precoAtual) : null,
+    precoAnterior:
+      Number.isFinite(precoAnterior) ? Number(Number(precoAnterior).toFixed(2)) : null,
+    precoAnteriorFormatado: Number.isFinite(precoAnterior) ? formatCurrency(precoAnterior) : null,
+    melhorPreco,
+    registrosAtuais: atuais.length,
+    pontosHistorico: serie.length,
+    serie,
+    sugestao: gerarSugestao(grao, tendencia, variacaoPercentual, melhorPreco, serie.length),
+  };
+}
+
+function consolidarSerie(historico) {
+  const byDate = new Map();
+
+  for (const item of historico) {
+    const date = toDateKey(item.data);
+    if (!date) continue;
+
+    const current = byDate.get(date) || [];
+    current.push(Number(item.preco));
+    byDate.set(date, current);
+  }
+
+  return Array.from(byDate.entries())
+    .map(([date, values]) => ({
+      date,
+      price: Number(media(values).toFixed(2)),
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+function calcularEstatisticas(cotacoes) {
+  if (cotacoes.length === 0) {
+    return {
+      totalCotacoes: 0,
+      maiorCotacao: null,
+      menorCotacao: null,
+      mediaPreco: null,
+      mediaPrecoFormatada: null,
+      ultimaAtualizacao: null,
+    };
+  }
+
+  const ordenadas = [...cotacoes].sort((a, b) => b.preco - a.preco);
+  const ultimaAtualizacao = cotacoes
+    .map((item) => item.data_hora || item.dataAtualizacaoCache)
+    .filter(Boolean)
+    .sort()
+    .at(-1);
+  const mediaPreco = media(cotacoes.map((item) => item.preco));
+
+  return {
+    totalCotacoes: cotacoes.length,
+    maiorCotacao: formatResumoCotacao(ordenadas[0]),
+    menorCotacao: formatResumoCotacao(ordenadas[ordenadas.length - 1]),
+    mediaPreco: Number(mediaPreco.toFixed(2)),
+    mediaPrecoFormatada: formatCurrency(mediaPreco),
+    ultimaAtualizacao,
+  };
+}
+
+function formatResumoCotacao(item) {
+  if (!item) return null;
+
+  return {
+    grao: item.grao,
+    cooperativa: item.provedor,
+    preco: item.preco,
+    precoFormatado: item.precoFormatado,
+    local: item.local,
+    data_hora: item.data_hora,
+  };
+}
+
+function gerarResumo(analises, estatisticas) {
+  if (analises.length === 0 || estatisticas.totalCotacoes === 0) {
+    return 'Ainda nao ha dados suficientes de cotacoes para gerar uma analise confiavel.';
+  }
+
+  const altas = analises.filter((item) => item.tendencia === 'alta').length;
+  const quedas = analises.filter((item) => item.tendencia === 'queda').length;
+  const estaveis = analises.filter((item) => item.tendencia === 'estabilidade').length;
+
+  if (altas > quedas && altas > estaveis) {
+    return 'As cotacoes analisadas indicam predominio de alta nos ultimos registros disponiveis.';
+  }
+
+  if (quedas > altas && quedas > estaveis) {
+    return 'As cotacoes analisadas indicam maior pressao de queda nos ultimos registros disponiveis.';
+  }
+
+  return 'As cotacoes analisadas estao majoritariamente estaveis ou com variacoes moderadas.';
+}
+
+function gerarSugestao(grao, tendencia, variacaoPercentual, melhorPreco, pontosHistorico) {
+  if (pontosHistorico < 2 || variacaoPercentual === null) {
+    return `Ainda nao ha historico suficiente para estimar uma tendencia confiavel para ${grao}.`;
+  }
+
+  const destino = melhorPreco ? ` Melhor preco atual encontrado em ${melhorPreco.cooperativa}.` : '';
+
+  if (tendencia === 'alta') {
+    return `${grao} apresenta tendencia de alta nos ultimos registros.${destino}`;
+  }
+
+  if (tendencia === 'queda') {
+    return `${grao} apresentou queda recente; acompanhe novas atualizacoes antes de decidir.${destino}`;
+  }
+
+  return `${grao} esta relativamente estavel; recomenda-se acompanhar as proximas cotacoes.${destino}`;
+}
+
+function classificarTendencia(variacaoPercentual) {
+  if (variacaoPercentual === null || !Number.isFinite(variacaoPercentual)) return 'indefinida';
+  if (variacaoPercentual > 1) return 'alta';
+  if (variacaoPercentual < -1) return 'queda';
+  return 'estabilidade';
+}
+
+function normalizarGrao(value = '') {
+  const normalized = String(value)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toUpperCase();
+
+  if (normalized.includes('SOJA')) return 'SOJA';
+  if (normalized.includes('MILHO')) return 'MILHO';
+  if (normalized.includes('TRIGO')) return 'TRIGO';
+  if (normalized.includes('CAFE')) return 'CAFE';
+  if (normalized.includes('FEIJAO')) return 'FEIJAO';
+
+  return normalized.trim();
+}
+
+function parsePreco(value) {
+  if (typeof value === 'number') return value;
+  if (!value || typeof value !== 'string') return null;
+
+  const match = value.replace(/\u00a0/g, ' ').match(/\d{1,3}(?:\.\d{3})*,\d{2}|\d+(?:[.,]\d{1,2})?/);
+  if (!match) return null;
+
+  const parsed = Number(match[0].replace(/\./g, '').replace(',', '.'));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function media(values) {
+  const valid = values.filter((value) => Number.isFinite(value));
+  if (valid.length === 0) return NaN;
+
+  return valid.reduce((total, value) => total + value, 0) / valid.length;
+}
+
+function formatCurrency(value) {
+  return Number(value).toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function toDateKey(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+
+  return date.toISOString().slice(0, 10);
+}

--- a/frontend/src/pages/dashboard/Dashboard.jsx
+++ b/frontend/src/pages/dashboard/Dashboard.jsx
@@ -1,7 +1,18 @@
 // src/pages/dashboard/Dashboard.jsx
 import React, { useState, useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
-import { Calendar, TrendingUp, TrendingDown } from 'lucide-react';
+import { Calendar, TrendingUp, TrendingDown, BrainCircuit, BarChart3, AlertCircle } from 'lucide-react';
+import {
+  BarChart,
+  Bar,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
 import Footer from '../../componentes/footer';
 import Navbar from '../../componentes/navbar';
 import { useCotacoes } from '../../hooks/useCotacoes';
@@ -64,6 +75,43 @@ const mapearProdutoCotacao = (item) => {
 
 const mapearProdutosCotacao = (items) =>
   items.map(mapearProdutoCotacao).filter(Boolean);
+
+const parsePrecoDisplay = (preco = '') => {
+  const match = String(preco).match(/\d{1,3}(?:\.\d{3})*,\d{2}|\d+(?:[.,]\d{1,2})?/);
+  if (!match) return null;
+
+  const value = Number(match[0].replace(/\./g, '').replace(',', '.'));
+  return Number.isFinite(value) ? value : null;
+};
+
+const formatarMoeda = (value) =>
+  Number.isFinite(value)
+    ? value.toLocaleString('pt-BR', {
+        style: 'currency',
+        currency: 'BRL',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })
+    : 'Sem dados';
+
+const formatarDataCurta = (value) => {
+  if (!value) return 'Sem atualização';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value);
+
+  return date.toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+};
+
+const trendStyles = {
+  alta: 'bg-green-50 text-green-700 border-green-100',
+  queda: 'bg-red-50 text-red-700 border-red-100',
+  estabilidade: 'bg-amber-50 text-amber-700 border-amber-100',
+  indefinida: 'bg-gray-50 text-gray-600 border-gray-100',
+};
 
 function transformarCotacoesParaCooperativas(cotacoes) {
   if (!cotacoes || typeof cotacoes !== 'object') return [];
@@ -244,6 +292,9 @@ const DashboardPage = () => {
   const [historySeries, setHistorySeries] = useState([]);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [historyError, setHistoryError] = useState(null);
+  const [analiseCotacoes, setAnaliseCotacoes] = useState(null);
+  const [analiseLoading, setAnaliseLoading] = useState(false);
+  const [analiseError, setAnaliseError] = useState(null);
   
   const {
     searchTerm,
@@ -262,6 +313,33 @@ const DashboardPage = () => {
     console.log('API cotacoes:', cotacoes);
     if (error) console.error('Erro cotacoes:', error);
   }, [cotacoes, error]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function loadAnalise() {
+      try {
+        setAnaliseLoading(true);
+        setAnaliseError(null);
+        const params = new URLSearchParams();
+        params.set('period', timeRange);
+        const resp = await axios.get(`${API_URL}/cotacoes/analise?${params.toString()}`, {
+          signal: controller.signal,
+        });
+        setAnaliseCotacoes(resp.data);
+      } catch (e) {
+        if (e.name !== 'CanceledError') {
+          setAnaliseError('Nao foi possivel gerar a analise das cotacoes.');
+          setAnaliseCotacoes(null);
+        }
+      } finally {
+        setAnaliseLoading(false);
+      }
+    }
+
+    loadAnalise();
+    return () => controller.abort();
+  }, [timeRange]);
 
   // Lê ?tab=historico para abrir a aba correta via deep link
   useEffect(() => {
@@ -352,6 +430,56 @@ const DashboardPage = () => {
   }, [apiCooperativas]);
 
   // Dados atuais para o histórico (preferir série real)
+  const cotacoesAtuaisGrafico = useMemo(() => {
+    return displayedData
+      .flatMap((coop) =>
+        coop.produtos.map((produto) => ({
+          label: `${produto.nome} - ${coop.nome}`,
+          grao: produto.nome,
+          cooperativa: coop.nome,
+          preco: parsePrecoDisplay(produto.preco) || 0,
+        }))
+      )
+      .filter((item) => item.preco > 0);
+  }, [displayedData]);
+
+  const resumoCotacoes = useMemo(() => {
+    const stats = analiseCotacoes?.estatisticas;
+    if (stats?.totalCotacoes > 0) {
+      return {
+        maior: stats.maiorCotacao,
+        menor: stats.menorCotacao,
+        media: stats.mediaPrecoFormatada,
+        ultimaAtualizacao: stats.ultimaAtualizacao,
+        total: stats.totalCotacoes,
+      };
+    }
+
+    const all = cotacoesAtuaisGrafico;
+    if (all.length === 0) {
+      return { maior: null, menor: null, media: null, ultimaAtualizacao: null, total: 0 };
+    }
+
+    const sorted = [...all].sort((a, b) => b.preco - a.preco);
+    const mediaAtual = all.reduce((sum, item) => sum + item.preco, 0) / all.length;
+
+    return {
+      maior: {
+        grao: sorted[0].grao,
+        cooperativa: sorted[0].cooperativa,
+        precoFormatado: formatarMoeda(sorted[0].preco),
+      },
+      menor: {
+        grao: sorted[sorted.length - 1].grao,
+        cooperativa: sorted[sorted.length - 1].cooperativa,
+        precoFormatado: formatarMoeda(sorted[sorted.length - 1].preco),
+      },
+      media: formatarMoeda(mediaAtual),
+      ultimaAtualizacao: null,
+      total: all.length,
+    };
+  }, [analiseCotacoes, cotacoesAtuaisGrafico]);
+
   const chartData = historySeries.length > 0
     ? historySeries
     : (timeRange === '6m' ? historyData[currentGrain].data6m : historyData[currentGrain].data1y);
@@ -401,6 +529,89 @@ const DashboardPage = () => {
                 cooperativasDisponiveis={cooperativasDisponiveisLocal}
                 onClear={limparFiltros}
               />
+
+              {error && (
+                <div className="mt-4 flex items-center gap-2 rounded-lg border border-red-100 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">
+                  <AlertCircle size={16} />
+                  {error}
+                </div>
+              )}
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mt-4">
+                <div className="bg-white dark:bg-[#14241d] rounded-xl border border-gray-200 dark:border-white/10 p-4 shadow-sm">
+                  <p className="text-xs font-bold uppercase text-gray-500">Maior cotacao</p>
+                  <p className="mt-2 text-xl font-black text-[#012d1d] dark:text-white">{resumoCotacoes.maior?.precoFormatado || 'Sem dados'}</p>
+                  <p className="text-xs font-semibold text-gray-500">{resumoCotacoes.maior ? `${resumoCotacoes.maior.grao} - ${resumoCotacoes.maior.cooperativa}` : 'Aguardando cotacoes'}</p>
+                </div>
+                <div className="bg-white dark:bg-[#14241d] rounded-xl border border-gray-200 dark:border-white/10 p-4 shadow-sm">
+                  <p className="text-xs font-bold uppercase text-gray-500">Menor cotacao</p>
+                  <p className="mt-2 text-xl font-black text-[#012d1d] dark:text-white">{resumoCotacoes.menor?.precoFormatado || 'Sem dados'}</p>
+                  <p className="text-xs font-semibold text-gray-500">{resumoCotacoes.menor ? `${resumoCotacoes.menor.grao} - ${resumoCotacoes.menor.cooperativa}` : 'Aguardando cotacoes'}</p>
+                </div>
+                <div className="bg-white dark:bg-[#14241d] rounded-xl border border-gray-200 dark:border-white/10 p-4 shadow-sm">
+                  <p className="text-xs font-bold uppercase text-gray-500">Media de preco</p>
+                  <p className="mt-2 text-xl font-black text-[#012d1d] dark:text-white">{resumoCotacoes.media || 'Sem dados'}</p>
+                  <p className="text-xs font-semibold text-gray-500">{resumoCotacoes.total || 0} cotacoes consideradas</p>
+                </div>
+                <div className="bg-white dark:bg-[#14241d] rounded-xl border border-gray-200 dark:border-white/10 p-4 shadow-sm">
+                  <p className="text-xs font-bold uppercase text-gray-500">Ultima atualizacao</p>
+                  <p className="mt-2 text-xl font-black text-[#012d1d] dark:text-white">{formatarDataCurta(resumoCotacoes.ultimaAtualizacao)}</p>
+                  <p className="text-xs font-semibold text-gray-500">Cache e historico do mercado</p>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 xl:grid-cols-5 gap-4 mt-4">
+                <div className="xl:col-span-2 bg-white dark:bg-[#14241d] rounded-xl border border-gray-200 dark:border-white/10 p-4 shadow-sm">
+                  <div className="flex items-center gap-2 mb-3">
+                    <BrainCircuit size={18} className="text-[#012d1d] dark:text-[#a5d0b9]" />
+                    <h2 className="text-sm font-black text-[#012d1d] dark:text-white uppercase tracking-wide">Analise inteligente</h2>
+                  </div>
+                  {analiseLoading ? (
+                    <p className="text-sm font-medium text-gray-500">Gerando analise das cotacoes...</p>
+                  ) : analiseError ? (
+                    <p className="text-sm font-medium text-red-600">{analiseError}</p>
+                  ) : (
+                    <>
+                      <p className="text-sm font-semibold text-gray-700 dark:text-gray-200">{analiseCotacoes?.resumo || 'Ainda nao ha dados suficientes para analise.'}</p>
+                      <div className="mt-4 space-y-2">
+                        {(analiseCotacoes?.graos || []).slice(0, 3).map((item) => (
+                          <div key={item.grao} className="rounded-lg border border-gray-100 dark:border-white/10 px-3 py-2">
+                            <div className="flex items-center justify-between gap-2">
+                              <span className="text-sm font-black text-[#012d1d] dark:text-white">{item.grao}</span>
+                              <span className={`rounded-full border px-2 py-0.5 text-xs font-bold ${trendStyles[item.tendencia] || trendStyles.indefinida}`}>
+                                {item.tendencia}
+                              </span>
+                            </div>
+                            <p className="mt-1 text-xs font-medium text-gray-500">{item.sugestao}</p>
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  )}
+                </div>
+
+                <div className="xl:col-span-3 bg-white dark:bg-[#14241d] rounded-xl border border-gray-200 dark:border-white/10 p-4 shadow-sm">
+                  <div className="flex items-center gap-2 mb-3">
+                    <BarChart3 size={18} className="text-[#012d1d] dark:text-[#a5d0b9]" />
+                    <h2 className="text-sm font-black text-[#012d1d] dark:text-white uppercase tracking-wide">Comparativo atual</h2>
+                  </div>
+                  {cotacoesAtuaisGrafico.length > 0 ? (
+                    <div className="h-64">
+                      <ResponsiveContainer width="100%" height="100%">
+                        <BarChart data={cotacoesAtuaisGrafico.slice(0, 12)} margin={{ top: 8, right: 8, left: 0, bottom: 42 }}>
+                          <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                          <XAxis dataKey="label" angle={-30} textAnchor="end" interval={0} height={62} tick={{ fontSize: 10 }} />
+                          <YAxis tickFormatter={(value) => `R$ ${value}`} width={56} />
+                          <Tooltip formatter={(value) => [formatarMoeda(Number(value)), 'Preco']} />
+                          <Bar dataKey="preco" fill="#1B4332" radius={[4, 4, 0, 0]} />
+                        </BarChart>
+                      </ResponsiveContainer>
+                    </div>
+                  ) : (
+                    <p className="text-sm font-medium text-gray-500">Nenhum dado disponivel para comparar no momento.</p>
+                  )}
+                </div>
+              </div>
 
               <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 mt-4">
                 <div className="lg:col-span-1">
@@ -551,6 +762,31 @@ const DashboardPage = () => {
                   icon={Calendar}
                   gradient="from-blue-500 to-blue-600"
                 />
+              </div>
+
+              <div className="bg-white dark:bg-[#14241d] rounded-[1.5rem] shadow-sm border border-gray-200 dark:border-white/10 p-4">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-4">
+                  <div>
+                    <h2 className="text-lg font-extrabold text-primary dark:text-[#c0edd4] font-manrope">Evolucao historica</h2>
+                    <p className="text-xs font-semibold text-gray-500 dark:text-gray-400">{historyCoop} {historyGrao ? `- ${historyGrao}` : '- todos os graos'}</p>
+                  </div>
+                  {historyLoading && <span className="text-xs font-bold text-gray-500">Carregando...</span>}
+                </div>
+                {chartData && chartData.length > 0 ? (
+                  <div className="h-72">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart data={chartData} margin={{ top: 8, right: 18, left: 0, bottom: 8 }}>
+                        <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                        <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+                        <YAxis tickFormatter={(value) => `R$ ${Number(value).toFixed(0)}`} width={58} />
+                        <Tooltip formatter={(value) => [formatarMoeda(Number(value)), 'Preco']} />
+                        <Line type="monotone" dataKey="price" stroke="#1B4332" strokeWidth={3} dot={{ r: 3 }} activeDot={{ r: 5 }} />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  </div>
+                ) : (
+                  <p className="py-10 text-center text-sm font-semibold text-gray-500">Nenhum dado historico encontrado para os filtros atuais.</p>
+                )}
               </div>
 
               {/* Historical Minimalist Table Section */}

--- a/readme.md
+++ b/readme.md
@@ -56,8 +56,9 @@ AgroSmart/
 - Login com JWT para usuários e administradores.
 - Senhas de usuários com hash bcrypt.
 - Recuperação e redefinição de senha por e-mail.
-- Dashboard de cotações, filtros por grão/cooperativa e histórico.
+- Dashboard de cotações com cards de resumo, filtros por grão/cooperativa, histórico e gráficos comparativos.
 - Cache e histórico de cotações no PostgreSQL.
+- Análise inteligente simples de cotações, baseada em regras e estatísticas do histórico.
 - Consulta climática via OpenWeatherMap.
 - FAQ público com gravação no banco.
 - Consulta técnica via API RespondeAgro da Embrapa.
@@ -285,6 +286,9 @@ npm run build:backend
 | POST | `/api/reset-password` | Redefinição de senha |
 | GET | `/api/cotacoes/todos` | Cotações cacheadas/agregadas |
 | GET | `/api/cotacoes/historico` | Histórico de cotações |
+| GET | `/api/cotacoes/analise` | Análise simples de tendência, variação e melhores preços |
+| POST | `/api/cotacoes/refresh` | Atualiza o cache de cotações a partir da API externa |
+| GET | `/api/cotacoes/cache-status` | Diagnóstico do cache e disponibilidade de cotação do dia |
 | GET/POST | `/api/faq` | Mensagens de FAQ |
 | GET | `/api/responde-agro` | Consulta técnica Embrapa |
 | GET | `/api/configuracao/:usuario_id` | Dados do perfil |
@@ -292,6 +296,41 @@ npm run build:backend
 | PATCH | `/api/usuarios/:id/status` | Alteração de status |
 | GET | `/api/tabelas` | Listagem de tabelas |
 | GET | `/api/tabelas/:tabela` | Dados de uma tabela |
+
+## Painel de Cotações e Análise Inteligente
+
+O painel de cotações usa dados de `/api/cotacoes/todos`, histórico de `/api/cotacoes/historico` e a rota `/api/cotacoes/analise` para exibir:
+
+- cards de maior cotação, menor cotação, média de preço e última atualização;
+- gráfico comparativo das cotações atuais;
+- gráfico de evolução histórica por cooperativa, grão e período;
+- resumo inteligente com tendência de alta, queda, estabilidade ou dados insuficientes;
+- sugestão textual simples para o produtor com base em variação percentual e melhor preço encontrado.
+
+A análise inteligente não depende de API paga de IA. Ela usa regras determinísticas, estatística básica e os registros salvos em `tb_cotacoes_cache` e `tb_cotacoes_historico`.
+
+Teste da análise no backend:
+
+```http
+GET /api/cotacoes/analise?period=30d
+Authorization: Bearer <token>
+```
+
+Filtros aceitos:
+
+```text
+period=7d | 30d | 6m | 1y
+grao=SOJA | MILHO | TRIGO | CAFE | FEIJAO
+```
+
+Exemplo:
+
+```http
+GET /api/cotacoes/analise?grao=SOJA&period=6m
+Authorization: Bearer <token>
+```
+
+Limitações: a análise depende da qualidade e frequência das fontes de cotação. Quando há poucos registros históricos, a API retorna mensagem de dados insuficientes em vez de inferir tendência artificialmente.
 
 ## Segurança e Boas Práticas
 


### PR DESCRIPTION
## Resumo`n- Adiciona service e rota /api/cotacoes/analise com analise simples de tendencia, variacao percentual, melhores precos e resumo automatico.`n- Melhora o dashboard de cotacoes com cards de resumo, grafico comparativo, bloco de analise inteligente e grafico de historico.`n- Atualiza README com as novas rotas, como testar e limitacoes da analise.`n`n## Commits logicos`n- feat: add cotacoes analysis endpoint`n- feat: enhance cotacoes dashboard insights`n- docs: document cotacoes analytics`n`n## Validacao`n- Node/npm nao estao disponiveis no terminal local; validacao sera feita pelos checks remotos.